### PR TITLE
Adiciona spiders para São Paulo (cidade), Fortaleza, Poços de Caldas, Linhares e São José dos Campos

### DIFF
--- a/assessorai_crawler/settings.py
+++ b/assessorai_crawler/settings.py
@@ -92,3 +92,6 @@ ITEM_PIPELINES = {
 
 # Set settings whose default value is deprecated to a future-proof value
 FEED_EXPORT_ENCODING = "utf-8"
+
+# Defina um timeout geral para os downloads para evitar que o spider fique preso.
+DOWNLOAD_TIMEOUT = 30

--- a/assessorai_crawler/spiders/proposicoescidsp.py
+++ b/assessorai_crawler/spiders/proposicoescidsp.py
@@ -1,0 +1,194 @@
+# Arquivo: assessorai_crawler/spiders/proposicoescidsp.py
+import scrapy
+import hashlib
+import json 
+import re
+import io
+import fitz  # PyMuPDF
+from datetime import datetime
+from urllib.parse import urlencode 
+from ..items import ProposicaoItem
+
+class ProposicoescidspSpider(scrapy.Spider):
+    """
+    Coleta proposições da Câmara Municipal de São Paulo, processando os PDFs associados.
+    """
+    name = 'proposicoescidsp'
+    house = 'Câmara Municipal de São Paulo'
+    uf = 'SP'
+    slug = 'proposicoescidsp'
+    allowed_domains = ['splegisconsulta.saopaulo.sp.leg.br', 'splegispdarmazenamento.blob.core.windows.net']
+    ajax_url = 'https://splegisconsulta.saopaulo.sp.leg.br/Pesquisa/PageDataProjeto'
+    
+    # O spider usará as configurações de delay e concorrência do settings.py
+    
+    items_per_page_ajax = 100 # Busca em pacotes de 100 para eficiência
+
+    def __init__(self, limit=None, *args, **kwargs):
+        """
+        Permite limitar a coleta via linha de comando: -a limit=100
+        """
+        super(ProposicoescidspSpider, self).__init__(*args, **kwargs)
+        self.total_items_limit = int(limit) if limit else None
+        self.items_processed_count = 0
+        
+        if self.total_items_limit:
+            self.logger.info(f"Coleta limitada a {self.total_items_limit} itens.")
+        else:
+            self.logger.info("Coletando todos os itens encontrados.")
+
+    def start_requests(self):
+        """ Inicia a coleta fazendo a primeira requisição para a API de listagem. """
+        params = {
+            'draw': '1', 'start': '0', 'length': str(self.items_per_page_ajax),
+            'tipo': '0', 'somenteEmTramitacao': 'false',
+            'order[0][column]': '1', 'order[0][dir]': 'desc',
+            'search[value]': '', 'search[regex]': 'false',
+        }
+        headers = {'X-Requested-With': 'XMLHttpRequest', 'Referer': 'https://splegisconsulta.saopaulo.sp.leg.br/Pesquisa/IndexProjeto'}
+        yield scrapy.FormRequest(url=self.ajax_url, formdata=params, headers=headers, callback=self.parse, meta={'params_template': params.copy()})
+
+    def parse(self, response, **kwargs):
+        """ Processa a lista de proposições e dispara requisições para os PDFs. """
+        data_json = json.loads(response.text)
+        proposicoes_ajax = data_json.get('data', [])
+
+        for ajax_data in proposicoes_ajax:
+            if self.total_items_limit and self.items_processed_count >= self.total_items_limit:
+                self.logger.info(f"Limite de {self.total_items_limit} itens atingido. Encerrando.")
+                return
+
+            self.items_processed_count += 1
+            
+            # Cria um item parcial com os dados do JSON da lista
+            item = self.create_item_from_ajax(ajax_data, response)
+            if not item:
+                continue
+
+            # Dispara a requisição para o PDF, passando o item parcial
+            yield scrapy.Request(url=item['url'], callback=self.parse_pdf_content, errback=self.handle_pdf_error, meta={'item': item})
+        
+        # Lógica de Paginação: continua se não houver limite ou se ele não foi atingido
+        if not self.total_items_limit or self.items_processed_count < self.total_items_limit:
+            yield self.get_next_page_request(response, data_json)
+
+    def create_item_from_ajax(self, ajax_data, response):
+        """ Cria e preenche um item parcial com os dados da listagem AJAX. """
+        codigo_processo = ajax_data.get('codigo')
+        if not codigo_processo:
+            return None
+
+        item = ProposicaoItem()
+        item['house'] = self.house
+        item['title'] = ajax_data.get('texto', '').strip()
+        item['type'] = ajax_data.get('sigla', '').strip()
+        item['number'] = ajax_data.get('numero')
+        item['year'] = ajax_data.get('ano')
+        item['author'] = [p.get('texto', '').strip() for p in ajax_data.get('promoventes', [])]
+        item['subject'] = ajax_data.get('ementa', '').strip()
+        item['scraped_at'] = datetime.now().isoformat()
+        item['meta'] = {'source_json_codigo': codigo_processo}
+        
+        pdf_link_template = "/ArquivoProcesso/GerarArquivoProcessoPorID/{codigo}?referidas=true" if ajax_data.get('natodigital') else "/ArquivoProcesso/GerarArquivoProcessoPorID/{codigo}?filtroAnexo=1"
+        item['url'] = response.urljoin(pdf_link_template.format(codigo=codigo_processo))
+        item['uuid'] = hashlib.md5(str(codigo_processo).encode('utf-8')).hexdigest()
+        return item
+
+    def get_next_page_request(self, response, data_json):
+        """ Monta a requisição para a próxima página de resultados, se houver. """
+        records_filtered = data_json.get('recordsFiltered', 0)
+        current_start_offset = int(response.meta.get('params_template', {}).get('start', 0))
+        next_page_start_offset = current_start_offset + self.items_per_page_ajax
+
+        if next_page_start_offset < records_filtered:
+            params_template = response.meta.get('params_template')
+            next_params = params_template.copy()
+            next_params['draw'] = str(int(params_template.get('draw', 1)) + 1)
+            next_params['start'] = str(next_page_start_offset)
+            
+            self.logger.info(f"Buscando próxima página. Start: {next_page_start_offset}")
+            return scrapy.FormRequest(url=self.ajax_url, formdata=next_params, headers=response.request.headers, callback=self.parse, meta={'params_template': next_params})
+
+    def handle_pdf_error(self, failure):
+        """ Lida com falhas no download do PDF (timeout, 404, etc.). """
+        item = failure.request.meta['item']
+        self.logger.error(f"Falha ao baixar PDF para '{item['title']}'. URL: {item['url']}. Erro: {failure.value}")
+        item['full_text'] = "[PDF_NAO_LOCALIZADO]"
+        item['length'] = len(item['full_text'])
+        item['presentation_date'] = None
+        if item.is_complete():
+            yield item
+
+    def parse_pdf_content(self, response):
+        """ Processa o conteúdo do PDF baixado para extrair o texto e a data. """
+        item = response.meta['item']
+        try:
+            pdf_bytes = io.BytesIO(response.body)
+            pdf_document = fitz.open(stream=pdf_bytes, filetype="pdf")
+            texto_bruto = "".join([page.get_text("text") for page in pdf_document])
+            
+            if not texto_bruto.strip():
+                raise ValueError("PDF vazio ou sem texto extraível.")
+
+            corpo_bruto, sucesso = self.extrair_corpo_lei(texto_bruto)
+            if sucesso:
+                texto_limpo = self.limpar_texto_pdf(corpo_bruto)
+                texto_formatado = self.formatar_texto_lei(texto_limpo)
+                item['full_text'] = texto_formatado[:2500]
+            else:
+                item['full_text'] = "[PDF_ILEGIVEL]"
+            
+            item['presentation_date'] = self.extrair_data_apresentacao(texto_bruto)
+        except Exception as e:
+            self.logger.error(f"Falha ao processar conteúdo do PDF para '{item['title']}': {e}")
+            item['full_text'] = "[PDF_ILEGIVEL]"
+            item['presentation_date'] = None
+        
+        item['length'] = len(item['full_text'])
+        if item.is_complete():
+            yield item
+        else:
+            self.logger.warning(f"Item '{item['title']}' incompleto. Campos faltando: {item.missing_fields()}. Item descartado.")
+
+    # --- Métodos Auxiliares de Processamento de Texto ---
+    def extrair_corpo_lei(self, texto_bruto):
+        """ Isola o corpo da lei, começando em 'Ementa:'. Retorna o texto e um booleano de sucesso. """
+        match_inicio = re.search(r"Ementa:", texto_bruto, flags=re.IGNORECASE)
+        if not match_inicio:
+            return "", False
+        start_index = match_inicio.start()
+        match_fim = re.search(r"Sala das Sessões", texto_bruto, flags=re.IGNORECASE)
+        if not match_fim:
+            return texto_bruto[start_index:].strip(), True
+        end_index = match_fim.start()
+        return texto_bruto[start_index:end_index].strip(), True
+
+    def limpar_texto_pdf(self, texto_para_limpar):
+        """ Remove lixo de OCR, cabeçalhos e rodapés do bloco de texto. """
+        texto_limpo = re.sub(r"^\s*Palácio Anchieta.*$", "", texto_para_limpar, flags=re.MULTILINE)
+        texto_limpo = re.sub(r"^\s*PROJETO DE LEI Nº?.*$", "", texto_limpo, flags=re.IGNORECASE | re.MULTILINE)
+        texto_limpo = re.sub(r"^_+$", "", texto_limpo, flags=re.MULTILINE)
+        texto_limpo = re.sub(r"Matéria PL .*? conferida em.*$", "", texto_limpo, flags=re.IGNORECASE | re.MULTILINE)
+        texto_limpo = re.sub(r"autuado por .*$", "", texto_limpo, flags=re.IGNORECASE | re.MULTILINE)
+        texto_limpo = re.sub(r"fls\.\s*\d+", "", texto_limpo, flags=re.IGNORECASE)
+        texto_limpo = re.sub(r"Impresso n[oó] .*? da CMSP", "", texto_limpo, flags=re.IGNORECASE)
+        texto_limpo = re.sub(r"[«»”'´`‘]", "", texto_limpo)
+        texto_limpo = re.sub(r"cod\.\s*\d+", "", texto_limpo, flags=re.IGNORECASE)
+        return texto_limpo.strip()
+
+    def extrair_data_apresentacao(self, texto_bruto):
+        """ Usa regex para encontrar a data de apresentação no texto bruto. """
+        match = re.search(r"Sala das Sessões,?\s*(\d{1,2}\s+de\s+\w+\s+de\s+\d{4})", texto_bruto, flags=re.IGNORECASE)
+        if match: return match.group(1).strip()
+        match = re.search(r"PROJETO DE LEI.*?DE\s+(\d{2}/\d{2}/\d{4})", texto_bruto, flags=re.IGNORECASE)
+        if match: return match.group(1)
+        match = re.search(r"autuado por .*? em\s+(\d{2}/\d{2}/\d{4})", texto_bruto, flags=re.IGNORECASE)
+        if match: return match.group(1)
+        return None
+
+    def formatar_texto_lei(self, texto_bruto):
+        """ Formata o texto para uma única linha, sem quebras de linha. """
+        texto_corrigido = re.sub(r'-\n', '', texto_bruto)
+        texto_com_espacos = re.sub(r'\s*\n\s*', ' ', texto_corrigido)
+        texto_final = re.sub(r'\s{2,}', ' ', texto_com_espacos)
+        return texto_final.strip()

--- a/assessorai_crawler/spiders/proposicoesfortaleza.py
+++ b/assessorai_crawler/spiders/proposicoesfortaleza.py
@@ -1,0 +1,160 @@
+import scrapy
+import re
+import io
+import fitz  # PyMuPDF
+from datetime import datetime
+import hashlib
+from ..items import ProposicaoItem
+import html2text
+
+class ProposicoesFortalezaSpider(scrapy.Spider):
+    """
+    Coleta TODAS as proposições da Câmara Municipal de Fortaleza, implementando
+    paginação e seguindo a arquitetura do projeto AssessorAI.
+    """
+    name = 'proposicoesfortaleza'
+    house = 'Câmara Municipal de Fortaleza'
+    uf = 'CE'
+    slug = 'proposicoesfortaleza'
+    allowed_domains = ['sapl.fortaleza.ce.leg.br']
+    
+    custom_settings = {
+        'USER_AGENT': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        'DOWNLOAD_DELAY': 1 
+    }
+    
+    TIPOS_DOCUMENTO = {
+        #8: "Indicação",
+        #10: "Mensagem",
+        #12: "Parecer Prévio do Tribunal de Contas",
+        6: "Projeto de Decreto Legislativo",
+        9: "Projeto de Emenda à Lei Orgânica",
+        #13: "Projeto de Iniciativa Popular",
+        5: "Projeto de Lei Complementar",
+        1: "Projeto de Lei Ordinária",
+        #2: "Projeto de Resolução",
+        #14: "Protocolo da Casa",
+        #4: "Recurso",
+        #3: "Requerimento",
+        #11: "Veto"
+    }
+    TEXT_LIMIT = 2500
+
+    def start_requests(self):
+        """Gera as requisições iniciais para a PRIMEIRA página de cada tipo."""
+        base_url = "https://sapl.fortaleza.ce.leg.br/materia/pesquisar-materia"
+        self.logger.info(f"Iniciando coleta para os tipos: {list(self.TIPOS_DOCUMENTO.values())}")
+        for codigo in self.TIPOS_DOCUMENTO.keys():
+            url = f"{base_url}?page=1&tipo={codigo}"
+            yield scrapy.Request(url, callback=self.parse)
+
+    def parse(self, response):
+        """
+        Processa a página de listagem, extrai os itens e segue para a próxima página.
+        """
+        self.logger.info(f"Processando página de listagem: {response.url}")
+        
+        linhas = response.css('table.table-striped tr')
+        self.logger.info(f"Encontradas {len(linhas)} matérias para processar nesta página.")
+        
+        for linha in linhas:
+            item = self.extract_metadata_from_row(linha, response)
+            if item and item.get('url'):
+                yield scrapy.Request(
+                    url=item['url'],
+                    callback=self.parse_pdf,
+                    meta={'item': item}
+                )
+        
+        next_page_link = response.css('a.page-link:contains("Próxima")::attr(href)').get()
+        if next_page_link:
+            self.logger.info(f"Encontrada próxima página: {next_page_link}")
+            yield response.follow(next_page_link, callback=self.parse)
+        else:
+            self.logger.info(f"Fim da paginação para a URL: {response.url}")
+
+    def parse_pdf(self, response):
+        """Processa o PDF baixado, finaliza o item e o entrega para o Scrapy."""
+        item = response.meta['item']
+        self.logger.debug(f"Processando PDF para: {item['title']}")
+        
+        try:
+            texto_html = self._extract_full_text(response.body)
+            texto_markdown = self._convert_to_markdown(texto_html)
+            
+            item['full_text'] = texto_markdown[:self.TEXT_LIMIT]
+            item['length'] = len(item['full_text'])
+        except Exception as e:
+            self.logger.error(f"Falha ao processar PDF para '{item['title']}': {e}")
+            item['full_text'] = "[ERRO_AO_PROCESSAR_PDF]"
+            item['length'] = len(item['full_text'])
+        
+        if self.validate_item(item):
+            self.logger.info(f"Item VÁLIDO processado: {item['title']}")
+            yield item
+        else:
+            self.logger.warning(f"Item descartado por falha na validação: {item.get('title')}")
+
+    def extract_metadata_from_row(self, linha_selector, response):
+        item = ProposicaoItem()
+        link_titulo_tag = linha_selector.css('a')
+        if not link_titulo_tag: return None
+        texto_titulo_completo = link_titulo_tag.css('::text').get('').strip()
+        link_detalhes_relativo = link_titulo_tag.css('::attr(href)').get('')
+        match_titulo = re.search(r'(\w+)\s+(\d+)/(\d{4})\s+-\s+(.*)', texto_titulo_completo)
+        if match_titulo:
+            item['number'] = int(match_titulo.group(2))
+            item['year'] = int(match_titulo.group(3))
+            item['type'] = match_titulo.group(4).strip()
+            item['title'] = f"{item['type']} nº {item['number']}/{item['year']}"
+        else:
+            item['title'] = texto_titulo_completo
+        item['subject'] = linha_selector.css('div.dont-break-out::text').get('').strip()
+        item['presentation_date'] = linha_selector.xpath("string(.//strong[contains(text(), 'Apresentação:')]/following-sibling::text()[1])").get('').strip()
+        item['author'] = [linha_selector.xpath("string(.//strong[contains(text(), 'Autor:')]/following-sibling::text()[1])").get('').strip()]
+        pdf_relative_url = linha_selector.css('a:contains("Texto Original")::attr(href)').get()
+        if pdf_relative_url:
+            item['url'] = response.urljoin(pdf_relative_url)
+        item['house'] = self.house
+        item['scraped_at'] = datetime.now().isoformat()
+        item['uuid'] = hashlib.md5(response.urljoin(link_detalhes_relativo).encode('utf-8')).hexdigest()
+        return item
+
+    def _extract_full_text(self, pdf_body):
+        """
+        Extrai o conteúdo HTML bruto do corpo de um PDF.
+        O underscore (_) indica que é um método auxiliar interno.
+        """
+        if not pdf_body:
+            return ""
+        with fitz.open(stream=io.BytesIO(pdf_body), filetype="pdf") as doc:
+            return "".join(page.get_text("html") for page in doc)
+
+    def _convert_to_markdown(self, html_bruto):
+        """
+        Limpa o HTML bruto específico de Fortaleza e o converte para Markdown,
+        seguindo o padrão da documentação.
+        """
+        if not html_bruto:
+            return "[PDF SEM CONTEÚDO EXTRAÍVEL]"
+        
+        # 1. Conversão para Markdown 
+        h = html2text.HTML2Text()
+        h.ignore_links = True
+        h.ignore_images = True
+        h.body_width = 0
+        markdown = h.handle(html_bruto)
+        
+        # 2. Limpeza específica de Fortaleza
+        linhas_para_remover = [r'^\s*CÂMARA MUNICIPAL DE FORTALEZA.*$', r'^\s*GABINETE VEREADOR.*$']
+        for pattern in linhas_para_remover:
+            markdown = re.sub(pattern, '', markdown, flags=re.MULTILINE | re.IGNORECASE)
+        
+        # 3. Limpeza final no Markdown
+        markdown = re.sub(r'\n\s*\n', '\n\n', markdown)
+        return markdown.strip()
+
+    def validate_item(self, item):
+        if not item.get('title'): return False
+        if not item.get('full_text') or len(item['full_text']) < 50 or "[ERRO" in item['full_text']: return False
+        return True

--- a/assessorai_crawler/spiders/proposicoeslinhares.py
+++ b/assessorai_crawler/spiders/proposicoeslinhares.py
@@ -1,0 +1,190 @@
+# assessorai_crawler/spiders/proposicoeslinhares.py
+
+import scrapy
+from urllib.parse import urlparse, parse_qs, urljoin
+import io
+import fitz
+import re
+from datetime import datetime
+import hashlib
+from ..items import ProposicaoItem
+
+class ProposicoesLinharesSpider(scrapy.Spider):
+    """Coleta proposições da Câmara Municipal de Linhares."""
+    name = 'proposicoeslinhares'
+    house = 'Câmara Municipal de Linhares'
+    uf = 'ES'
+    slug = 'proposicoeslinhares'
+    allowed_domains = ['linhares.camarasempapel.com.br']
+    start_urls = ["https://linhares.camarasempapel.com.br/spl/consulta-producao.aspx?tipo=5003"]
+    
+    custom_settings = {
+        'DOWNLOAD_DELAY': 2,
+        'CONCURRENT_REQUESTS_PER_DOMAIN': 4,
+        'RETRY_TIMES': 3,
+        'ROBOTSTXT_OBEY': False, # Adicionado para garantir o acesso
+    }
+    
+    TEXT_LIMIT = 50000
+
+    def parse(self, response):
+        """Processa a página de listagem e segue para a próxima."""
+        proposicoes = response.css("div.kt-widget5__item")
+        
+        # Usa a configuração CLOSESPIDER_ITEMCOUNT para limitar, se necessário
+        for prop in proposicoes:
+            item = self.extract_metadata_from_list(prop, response)
+            if item and item.get('url'):
+                yield scrapy.Request(
+                    url=item['url'],
+                    callback=self.parse_process_page,
+                    meta={'item': item}
+                )
+        
+        # Lógica de paginação: clica no botão "Próxima"
+        next_page_button = response.css('a#ContentPlaceHolder1_lbNext')
+        if next_page_button and next_page_button.attrib.get('href'):
+            current_page_number = response.meta.get('page_number', 1)
+            next_page_number = current_page_number + 1
+            self.logger.info(f"Navegando para a página {next_page_number}...")
+
+            form_data = {
+                '__EVENTTARGET': 'ctl00$ContentPlaceHolder1$lbNext',
+                '__EVENTARGUMENT': '',
+                '__VIEWSTATE': response.css('input#__VIEWSTATE::attr(value)').get(),
+                '__VIEWSTATEGENERATOR': response.css('input#__VIEWSTATEGENERATOR::attr(value)').get(),
+                '__EVENTVALIDATION': response.css('input#__EVENTVALIDATION::attr(value)').get(),
+            }
+
+            yield scrapy.FormRequest(
+                url=response.url,
+                formdata=form_data,
+                callback=self.parse,
+                meta={'page_number': next_page_number}
+            )
+
+    def parse_process_page(self, response):
+        """Encontra o link do PDF na página do processo."""
+        item = response.meta['item']
+        caminho_pdf = None
+        
+        # Estratégia A: Tenta extrair o caminho do PDF da URL final (após redirecionamento)
+        url_final = response.url
+        parsed_url = urlparse(url_final)
+        query_params = parse_qs(parsed_url.query)
+        
+        if 'arquivo' in query_params and query_params['arquivo'][0]:
+            caminho_pdf = query_params['arquivo'][0]
+        else:
+            # Estratégia B: Procura o link na lista de documentos da página
+            pdf_links = response.css("ul#processo_arquivos a[href*='.pdf']")
+            link_encontrado = None
+            
+            for link in pdf_links:
+                link_text = link.css("::text").get('').upper()
+                if "PL " in link_text or "PROPOSIÇÃO" in link_text:
+                    link_encontrado = link.attrib['href']
+                    break
+            
+            if link_encontrado:
+                parsed_link = urlparse(link_encontrado)
+                query_params_link = parse_qs(parsed_link.query)
+                if 'arquivo' in query_params_link and query_params_link['arquivo'][0]:
+                    caminho_pdf = query_params_link['arquivo'][0]
+
+        if caminho_pdf:
+            base_pdf_url = "https://linhares.camarasempapel.com.br/"
+            url_direta_pdf = urljoin(base_pdf_url, caminho_pdf)
+            yield scrapy.Request(
+                url=url_direta_pdf,
+                callback=self.parse_pdf,
+                errback=self.handle_pdf_error,
+                meta={'item': item}
+            )
+        else:
+            item['full_text'] = "[FALHA] PDF não encontrado na página de documentos."
+            item['length'] = len(item['full_text'])
+            yield item
+
+    def handle_pdf_error(self, failure):
+        """Lida com falhas no download do PDF."""
+        item = failure.request.meta['item']
+        status = failure.value.response.status if hasattr(failure.value, 'response') else 'N/A'
+        self.logger.error(f"Falha ao baixar PDF para '{item['title']}'. Status: {status}")
+        item['full_text'] = f"[ERRO_DOWNLOAD_PDF_{status}]"
+        item['length'] = len(item['full_text'])
+        yield item
+
+    def parse_pdf(self, response):
+        """Processa o PDF baixado, extrai e limpa o texto."""
+        item = response.meta['item']
+        try:
+            with fitz.open(stream=io.BytesIO(response.body), filetype="pdf") as doc:
+                start_page_index = -1
+                padrao_inicio = r'PROJETO DE (LEI COMPLEMENTAR|LEI|RESOLUÇÃO|DECRETO LEGISLATIVO)\s+N[º°]'
+                for i, page in enumerate(doc):
+                    if re.search(padrao_inicio, page.get_text("text"), re.IGNORECASE):
+                        start_page_index = i
+                        break
+                if start_page_index == -1: start_page_index = 0
+                texto_bruto = "".join(doc[i].get_text("text") for i in range(start_page_index, len(doc)))
+                item['full_text'] = self.limpar_texto_pdf(texto_bruto)[:self.TEXT_LIMIT]
+        except Exception as e:
+            self.logger.error(f"Falha ao processar PDF para '{item['title']}': {e}")
+            item['full_text'] = "[ERRO_PROCESSAMENTO_PDF]"
+        
+        item['length'] = len(item['full_text'])
+        yield item
+
+    def extract_metadata_from_list(self, prop, response):
+        """Extrai os metadados da página de listagem."""
+        item = ProposicaoItem()
+        titulo_tag = prop.css("a.kt-widget5__title")
+        if not titulo_tag: return None
+        
+        item['title'] = titulo_tag.css('::text').get('').strip()
+        
+        match = re.search(r'^(.*?)\s+n°\s+(\d+)/(\d{4})', item['title'], re.IGNORECASE)
+        item['type'], _, item['year'] = (match.groups() if match else (None, None, None))
+        
+        protocolo_num = prop.xpath(".//span[contains(text(), 'Protocolo N°:')]/following-sibling::a[1]/text()").get()
+        if protocolo_num:
+            item['number'] = protocolo_num.strip()
+        elif match:
+            item['number'] = match.group(2)
+        else:
+            item['number'] = None
+
+        item['subject'] = prop.css("a.kt-widget5__desc::text").get('').strip()
+        autor_tag = prop.css("span.kt-font-info a")
+
+        autor_tag = prop.css("span.kt-font-info a")
+        if autor_tag:
+            autor_bruto = ''.join(autor_tag.css('::text').getall())
+            autor_limpo = re.sub(r'\s+', ' ', autor_bruto).strip()
+            item['author'] = [autor_limpo]
+        else:
+            item['author'] = []  
+
+        data_tag = prop.css("span.kt-font-info:contains('Data:') + span.kt-font-info")
+        item['presentation_date'] = data_tag.css('::text').get('').strip() if data_tag else None
+        item['house'] = self.house
+        item['scraped_at'] = datetime.now().isoformat()
+        link_detalhes_abs = response.urljoin(titulo_tag.attrib['href'])
+        item['uuid'] = hashlib.md5(link_detalhes_abs.encode('utf-8')).hexdigest()
+        link_processo_tag = prop.css("a[href*='Digital.aspx']")
+        item['url'] = response.urljoin(link_processo_tag.attrib['href']) if link_processo_tag else None
+        return item
+
+    def limpar_texto_pdf(self, texto_bruto):
+        """Aplica regras de limpeza específicas para os PDFs de Linhares."""
+        if not texto_bruto: return "[TEXTO NÃO EXTRAÍDO]"
+        texto_bruto = re.sub(r'.*<tJJaJácio;.*|.*nteJW!ll cgflas\).*|.*c!ÂIÚ\?AWIV.*|CCJ r!.*|~~CÚ!;~~.*', '', texto_bruto)
+        texto_bruto = re.sub(r'~+[^\s~]+~+', '', texto_bruto)
+        texto_bruto = re.sub(r'UNHARES', 'LINHARES', texto_bruto, flags=re.IGNORECASE)
+        texto_bruto = re.sub(r'INHARES-ES', 'LINHARES-ES', texto_bruto, flags=re.IGNORECASE)
+        match_justificativa = re.search(r'\n\s*JUSTIFICATIVA\s*\n', texto_bruto, re.IGNORECASE)
+        if match_justificativa: texto_bruto = texto_bruto[:match_justificativa.start()]
+        texto_processado = re.sub(r'\s*\n\s*', ' ', texto_bruto)
+        texto_final = re.sub(r'\s{2,}', ' ', texto_processado).strip()
+        return texto_final

--- a/assessorai_crawler/spiders/proposicoespocosdecaldas.py
+++ b/assessorai_crawler/spiders/proposicoespocosdecaldas.py
@@ -1,0 +1,219 @@
+import scrapy
+import re
+import io
+import fitz  # PyMuPDF
+from datetime import datetime
+import hashlib
+from ..items import ProposicaoItem
+
+class ProposicoesPocosDeCaldasSpider(scrapy.Spider):
+    """
+    Coleta as proposições da Câmara Municipal de Poços de Caldas de acordo com o dicionario de dados TIPOS_DOCUMENTO
+    """
+    name = 'proposicoespocosdecaldas'
+    house = 'Câmara Municipal de Poços de Caldas'
+    uf = 'MG'
+    slug = 'proposicoespocosdecaldas'
+    allowed_domains = ['pocosdecaldas.siscam.com.br']
+    
+    custom_settings = {
+        'USER_AGENT': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        'DOWNLOAD_DELAY': 1.5,
+        'CONCURRENT_REQUESTS_PER_DOMAIN': 8,
+        'ROBOTSTXT_OBEY': False
+    }
+    
+    # Dicionário de tipos de documento a serem coletados para Poços de Caldas. Há outros tipos disponíveis no site que não foram coletados.
+    TIPOS_DOCUMENTO = {
+        137: "Projeto de Decreto Legislativo",
+        139: "Projeto de Emenda à Lei Orgânica",
+        135: "Projeto de Lei",
+        136: "Projeto de Lei Complementar",
+    }
+    TEXT_LIMIT = 2500
+
+    def start_requests(self):
+        """
+        Gera as requisições iniciais para a PRIMEIRA página de cada tipo de documento.
+        """
+        base_url = "https://pocosdecaldas.siscam.com.br/Documentos/Pesquisa"
+        self.logger.info(f"Iniciando coleta para os tipos: {list(self.TIPOS_DOCUMENTO.values())}")
+        
+        for codigo_tipo in self.TIPOS_DOCUMENTO.keys():
+            url = f"{base_url}?id=80&pagina=1&Modulo=8&Documento={codigo_tipo}"
+            yield scrapy.Request(
+                url, 
+                callback=self.parse,
+                # Passamos o 'codigo_tipo' e 'page_number' para controlar a paginação
+                meta={'page_number': 1, 'codigo_tipo': codigo_tipo}
+            )
+
+    def parse(self, response):
+        """
+        Processa a página de listagem, extrai os itens e segue para a próxima página.
+        """
+        page_number = response.meta['page_number']
+        codigo_tipo = response.meta['codigo_tipo']
+        self.logger.info(f"Processando página {page_number} para o tipo de documento {codigo_tipo}.")
+        
+        proposicoes = response.css("div.data-list-item")
+        self.logger.info(f"Encontradas {len(proposicoes)} matérias para processar nesta página.")
+        
+        # Se a página não retornar itens, consideramos o fim da paginação para este tipo.
+        if not proposicoes:
+            self.logger.info(f"Nenhuma proposição encontrada na página {page_number}. Fim da paginação para o tipo {codigo_tipo}.")
+            return
+
+        for proposicao_selector in proposicoes:
+            item = self.extract_metadata(proposicao_selector, response)
+            if item and item.get('url'):
+                yield scrapy.Request(
+                    url=item['url'],
+                    callback=self.parse_pdf,
+                    meta={'item': item}
+                )
+        
+        # Lógica de paginação: constrói a URL da próxima página e continua a coleta.
+        next_page = page_number + 1
+        next_page_url = response.urljoin(f"?id=80&pagina={next_page}&Modulo=8&Documento={codigo_tipo}")
+        
+        self.logger.info(f"Agendando próxima página: {next_page_url}")
+        yield scrapy.Request(
+            next_page_url,
+            callback=self.parse,
+            meta={'page_number': next_page, 'codigo_tipo': codigo_tipo}
+        )
+
+    def parse_pdf(self, response):
+        """
+        Processa o PDF baixado, finaliza o item e o entrega para o Scrapy.
+        """
+        item = response.meta['item']
+        self.logger.debug(f"Processando PDF para: {item['title']}")
+        
+        try:
+            texto_limpo = self._process_and_clean_pdf_text(response.body)
+            item['full_text'] = texto_limpo[:self.TEXT_LIMIT]
+            item['length'] = len(item['full_text'])
+        except Exception as e:
+            self.logger.error(f"Falha ao processar PDF para '{item['title']}': {e}")
+            item['full_text'] = "[ERRO_AO_PROCESSAR_PDF]"
+            item['length'] = 0
+        
+        if self.validate_item(item):
+            self.logger.info(f"Item VÁLIDO processado: {item['title']}")
+            yield item
+        else:
+            self.logger.warning(f"Item descartado por falha na validação: {item.get('title')}")
+
+    def extract_metadata(self, proposicao_selector, response):
+        """
+        Extrai os metadados de uma única proposição na página de listagem.
+        """
+        item = ProposicaoItem()
+        
+        title_tag = proposicao_selector.css("h4 a")
+        if not title_tag:
+            return None
+
+        full_title_text = title_tag.css('::text').get('').strip()
+        link_detalhes_relativo = title_tag.css('::attr(href)').get('')
+
+        match = re.search(r'^(.*?)\s+Nº\s+(\d+)/(\d{4})', full_title_text, re.IGNORECASE)
+        if match:
+            item['type'] = match.group(1).strip()
+            item['number'] = int(match.group(2))
+            item['year'] = int(match.group(3))
+            item['title'] = f"{item['type']} nº {item['number']}/{item['year']}"
+        else:
+            item['title'] = full_title_text
+        
+        def get_text_from_p_tag(strong_text):
+            """
+            Função auxiliar para extrair texto de uma tag <p> que contém uma <strong> específica.
+            Ex: <p><strong>Assunto:</strong> Este é o assunto.</p> -> Retorna: "Este é o assunto."
+            """
+            p_tag_text = proposicao_selector.xpath(f".//p[strong[contains(text(), '{strong_text}')]]//text()").getall()
+            if not p_tag_text:
+                return None
+            
+            full_text = " ".join(p.strip() for p in p_tag_text).strip()
+            label_to_remove = f"{strong_text.strip()} " 
+            cleaned_text = full_text.replace(label_to_remove, "").strip()
+            return cleaned_text
+
+        autores_texto = get_text_from_p_tag("Autoria:")
+        item['author'] = [autor.strip() for autor in autores_texto.split(',')] if autores_texto else []
+        item['subject'] = get_text_from_p_tag("Assunto:")
+        item['presentation_date'] = get_text_from_p_tag("Data:")
+
+        pdf_link_tag = proposicao_selector.css('a[title="Documento Assinado"]::attr(href)').get()
+        if not pdf_link_tag:
+            pdf_link_tag = proposicao_selector.css('a[href*="/arquivo?Id="]::attr(href)').get()
+        
+        if pdf_link_tag:
+            item['url'] = response.urljoin(pdf_link_tag)
+
+        item['house'] = self.house
+        item['scraped_at'] = datetime.now().isoformat()
+        item['uuid'] = hashlib.md5(response.urljoin(link_detalhes_relativo).encode('utf-8')).hexdigest()
+        
+        return item
+    
+    def _process_and_clean_pdf_text(self, pdf_body):
+        """
+        Extrai o texto bruto do PDF e o passa para a função de limpeza.
+        O underscore (_) indica que é um método auxiliar interno.
+        """
+        if not pdf_body:
+            return ""
+            
+        with fitz.open(stream=io.BytesIO(pdf_body), filetype="pdf") as doc:
+            texto_bruto = "".join(page.get_text("text") for page in doc)
+        
+        return self._limpar_texto_extraido(texto_bruto)
+
+    def _limpar_texto_extraido(self, texto_bruto):
+        """
+        Aplica a lógica de limpeza com expressões regulares ao texto extraído do PDF.
+        """
+        if not texto_bruto:
+            return "[TEXTO NÃO EXTRAÍDO]"
+            
+        texto_processado = texto_bruto
+        match_inicio = re.search(r'PROJETO DE (LEI|DECRETO|EMENDA)', texto_processado, re.IGNORECASE)
+        if match_inicio:
+            texto_processado = texto_processado[match_inicio.start():]
+        else:
+            match_generico = re.search(r'Concede|Institui|Altera|Dispõe', texto_processado, re.IGNORECASE)
+            if match_generico:
+                texto_processado = texto_processado[match_generico.start():]
+        
+        match_justificativa = re.search(r'\n\s*JUSTIFICATIVA\s*\n', texto_processado, re.IGNORECASE)
+        if match_justificativa:
+            texto_processado = texto_processado[:match_justificativa.start()]
+        
+        match_fim = re.search(r'Plenário|Sala\s+"Ver\. José', texto_processado, re.IGNORECASE)
+        if match_fim:
+            texto_processado = texto_processado[:match_fim.start()]
+
+        texto_processado = re.sub(r'-\n', '', texto_processado)
+        texto_processado = re.sub(r'\s*\n\s*', ' ', texto_processado)
+        texto_final = re.sub(r'\s{2,}', ' ', texto_processado).strip()
+
+        if "JUNTA COMERCIAL" in texto_final.upper():
+            return "[DOCUMENTO INVÁLIDO - CONTRATO SOCIAL]"
+            
+        return texto_final
+
+    def validate_item(self, item):
+        """
+        Valida se o item extraído contém os campos essenciais para ser salvo.
+        """
+        if not all([item.get('title'), item.get('url'), item.get('uuid')]):
+            return False
+        
+        if not item.get('full_text') or len(item['full_text']) < 50 or "[ERRO" in item['full_text'] or "[DOCUMENTO INVÁLIDO" in item['full_text'] or "[TEXTO NÃO EXTRAÍDO" in item['full_text']:
+            return False
+
+        return True

--- a/assessorai_crawler/spiders/proposicoessjc.py
+++ b/assessorai_crawler/spiders/proposicoessjc.py
@@ -1,0 +1,181 @@
+# assessorai_crawler/spiders/proposicoessjc.py
+
+import scrapy
+from urllib.parse import urlparse, parse_qs, urljoin
+import io
+import fitz
+import re
+from datetime import datetime
+import hashlib
+from ..items import ProposicaoItem
+
+class ProposicoesSJCSpider(scrapy.Spider):
+    """Coleta proposições da Câmara Municipal de São José dos Campos."""
+    name = 'proposicoessjc'
+    house = 'Câmara Municipal de São José dos Campos'
+    uf = 'SP'
+    slug = 'proposicoessjc'
+    allowed_domains = ['camarasempapel.camarasjc.sp.gov.br']
+    start_urls = ["https://camarasempapel.camarasjc.sp.gov.br/spl/consulta-producao.aspx?tipo=348&procuraTexto=DocumentoInicial"]
+    
+    custom_settings = {
+        'DOWNLOAD_DELAY': 2,
+        'CONCURRENT_REQUESTS_PER_DOMAIN': 4,
+        'RETRY_TIMES': 3,
+        'ROBOTSTXT_OBEY': False,
+    }
+    
+    TEXT_LIMIT = 50000
+
+    def parse(self, response):
+        """Processa a página de listagem e segue para a próxima."""
+        proposicoes = response.css("div.kt-widget5__item")
+        
+        for prop in proposicoes:
+            item = self.extract_metadata_from_list(prop, response)
+            if item and item.get('url'):
+                yield scrapy.Request(
+                    url=item['url'],
+                    callback=self.parse_process_page,
+                    meta={'item': item}
+                )
+        
+        # Lógica de paginação: clica no botão "Próxima"
+        next_page_button = response.css('a#ContentPlaceHolder1_lbNext')
+        if next_page_button and next_page_button.attrib.get('href'):
+            current_page_number = response.meta.get('page_number', 1)
+            next_page_number = current_page_number + 1
+            self.logger.info(f"Navegando para a página {next_page_number}...")
+
+            form_data = {
+                '__EVENTTARGET': 'ctl00$ContentPlaceHolder1$lbNext',
+                '__EVENTARGUMENT': '',
+                '__VIEWSTATE': response.css('input#__VIEWSTATE::attr(value)').get(),
+                '__VIEWSTATEGENERATOR': response.css('input#__VIEWSTATEGENERATOR::attr(value)').get(),
+                '__EVENTVALIDATION': response.css('input#__EVENTVALIDATION::attr(value)').get(),
+            }
+
+            yield scrapy.FormRequest(
+                url=response.url,
+                formdata=form_data,
+                callback=self.parse,
+                meta={'page_number': next_page_number}
+            )
+
+    def parse_process_page(self, response):
+        """Encontra o link do PDF na página do processo."""
+        item = response.meta['item']
+        caminho_pdf = None
+        
+        url_final = response.url
+        parsed_url = urlparse(url_final)
+        query_params = parse_qs(parsed_url.query)
+        
+        if 'arquivo' in query_params and query_params['arquivo'][0]:
+            caminho_pdf = query_params['arquivo'][0]
+        else:
+            pdf_links = response.css("ul#processo_arquivos a[href*='.pdf']")
+            link_encontrado = None
+            
+            for link in pdf_links:
+                link_text = link.css("::text").get('').upper()
+                if "PL " in link_text or "PROPOSIÇÃO" in link_text:
+                    link_encontrado = link.attrib['href']
+                    break
+            
+            if link_encontrado:
+                parsed_link = urlparse(link_encontrado)
+                query_params_link = parse_qs(parsed_link.query)
+                if 'arquivo' in query_params_link and query_params_link['arquivo'][0]:
+                    caminho_pdf = query_params_link['arquivo'][0]
+
+        if caminho_pdf:
+            base_pdf_url = "https://camarasempapel.camarasjc.sp.gov.br/"
+            url_direta_pdf = urljoin(base_pdf_url, caminho_pdf)
+            yield scrapy.Request(
+                url=url_direta_pdf,
+                callback=self.parse_pdf,
+                errback=self.handle_pdf_error,
+                meta={'item': item}
+            )
+        else:
+            item['full_text'] = "[FALHA] PDF não encontrado na página de documentos."
+            item['length'] = len(item['full_text'])
+            yield item
+
+    def handle_pdf_error(self, failure):
+        """Lida com falhas no download do PDF."""
+        item = failure.request.meta['item']
+        status = failure.value.response.status if hasattr(failure.value, 'response') else 'N/A'
+        self.logger.error(f"Falha ao baixar PDF para '{item['title']}'. Status: {status}")
+        item['full_text'] = f"[ERRO_DOWNLOAD_PDF_{status}]"
+        item['length'] = len(item['full_text'])
+        yield item
+
+    def parse_pdf(self, response):
+        """Processa o PDF baixado, extrai e limpa o texto."""
+        item = response.meta['item']
+        try:
+            with fitz.open(stream=io.BytesIO(response.body), filetype="pdf") as doc:
+                start_page_index = -1
+                padrao_inicio = r'PROJETO DE (LEI COMPLEMENTAR|LEI|RESOLUÇÃO|DECRETO LEGISLATIVO)\s+N[º°]'
+                for i, page in enumerate(doc):
+                    if re.search(padrao_inicio, page.get_text("text"), re.IGNORECASE):
+                        start_page_index = i
+                        break
+                if start_page_index == -1: start_page_index = 0
+                texto_bruto = "".join(doc[i].get_text("text") for i in range(start_page_index, len(doc)))
+                item['full_text'] = self.limpar_texto_pdf(texto_bruto)[:self.TEXT_LIMIT]
+        except Exception as e:
+            self.logger.error(f"Falha ao processar PDF para '{item['title']}': {e}")
+            item['full_text'] = "[ERRO_PROCESSAMENTO_PDF]"
+        
+        item['length'] = len(item['full_text'])
+        yield item
+
+    def extract_metadata_from_list(self, prop, response):
+        """Extrai os metadados da página de listagem."""
+        item = ProposicaoItem()
+        titulo_tag = prop.css("a.kt-widget5__title")
+        if not titulo_tag: return None
+        
+        item['title'] = titulo_tag.css('::text').get('').strip()
+        
+        match = re.search(r'^(.*?)\s+n°\s+(\d+)/(\d{4})', item['title'], re.IGNORECASE)
+        item['type'], _, item['year'] = (match.groups() if match else (None, None, None))
+        
+        protocolo_num = prop.xpath(".//span[contains(text(), 'Protocolo N°:')]/following-sibling::a[1]/text()").get()
+        if protocolo_num:
+            item['number'] = protocolo_num.strip()
+        elif match:
+            item['number'] = match.group(2)
+        else:
+            item['number'] = None
+
+        item['subject'] = prop.css("a.kt-widget5__desc::text").get('').strip()
+        autor_tag = prop.css("span.kt-font-info a")
+        if autor_tag:
+            autor_bruto = ''.join(autor_tag.css('::text').getall())
+            autor_limpo = re.sub(r'\s+', ' ', autor_bruto).strip()
+            item['author'] = [autor_limpo]
+        else:
+            item['author'] = []
+            
+        data_tag = prop.css("span.kt-font-info:contains('Data:') + span.kt-font-info")
+        item['presentation_date'] = data_tag.css('::text').get('').strip() if data_tag else None
+        item['house'] = self.house
+        item['scraped_at'] = datetime.now().isoformat()
+        link_detalhes_abs = response.urljoin(titulo_tag.attrib['href'])
+        item['uuid'] = hashlib.md5(link_detalhes_abs.encode('utf-8')).hexdigest()
+        link_processo_tag = prop.css("a[href*='Digital.aspx']")
+        item['url'] = response.urljoin(link_processo_tag.attrib['href']) if link_processo_tag else None
+        return item
+
+    def limpar_texto_pdf(self, texto_bruto):
+        """Aplica regras de limpeza. Pode precisar de ajustes para SJC."""
+        if not texto_bruto: return "[TEXTO NÃO EXTRAÍDO]"
+        match_justificativa = re.search(r'\n\s*JUSTIFICATIVA\s*\n', texto_bruto, re.IGNORECASE)
+        if match_justificativa: texto_bruto = texto_bruto[:match_justificativa.start()]
+        texto_processado = re.sub(r'\s*\n\s*', ' ', texto_bruto)
+        texto_final = re.sub(r'\s{2,}', ' ', texto_processado).strip()
+        return texto_final

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tqdm
 tiktoken
 python-dotenv
 PyMuPDF
+html2text

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ weaviate-client
 tqdm
 tiktoken
 python-dotenv
+PyMuPDF


### PR DESCRIPTION
Criação de cinco novos spiders para a coleta de proposições legislativas e atualiza as dependências e configurações do projeto.

- **proposicoescidsp** (São Paulo - cidade): Coleta dados via endpoint AJAX, processando os resultados em JSON. A paginação é gerenciada pelos parâmetros start e length.

- **proposicoesfortaleza** (Fortaleza): Coleta dados do portal SAPL. O spider está configurado para buscar os seguintes tipos de documentos:
    - Projeto de Decreto Legislativo
    - Projeto de Emenda à Lei Orgânica
    - Projeto de Lei Complementar
    - Projeto de Lei Ordinária

- **proposicoespocosdecaldas** (Poços de Caldas): Coleta dados do portal Siscam. O spider está configurado para buscar os seguintes tipos de documentos:
    - Projeto de Decreto Legislativo
    - Projeto de Emenda à Lei Orgânica
    - Projeto de Lei
    - Projeto de Lei Complementar

- **proposicoeslinhares** - Cidade de Linhares
- **proposicoessjc** - Cidade de São José dos Campos
    - Estas duas usam o mesmo sistema de Câmara sem papel

- requirements.txt
    - Adicionado PyMuPDF para extração de texto de arquivos PDF.
    - Adicionado html2text para conversão de HTML para Markdown (usado no spider de Fortaleza).

- settings.py
    - Adicionado DOWNLOAD_TIMEOUT = 30 para definir um tempo limite de 30 segundos para as requisições, prevenindo que spiders fiquem bloqueados em downloads lentos.